### PR TITLE
Add license and link to project website

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+BSD 3-Clause
+
+=======================================================================
+
+Copyright 2018 Utrecht University
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ### Link Historical Names
-A custom module for the Artechne project that adds the functionality to (semi-)automatically link Historical Names to records.
+A custom Drupal module for the [Artechne project](https://artechne.wp.hum.uu.nl/) that adds the functionality to (semi-)automatically link Historical Names to records.
 
 Modules, in Drupal (7), reside at `sites/all/modules`.
 More on how to create custom modules [here](https://www.drupal.org/docs/7/creating-custom-modules/getting-started).


### PR DESCRIPTION
Not adding a `CITATION.cff` file, because this is a small Drupal module that implements only part of the functionality for this project.